### PR TITLE
Publish clasp.json to the repository.

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,0 +1,4 @@
+{
+  "scriptId": "11eBWI2aze9KiWYvhJUHTaxYKu8bOjBySKPs01tigY4oi-CWv9pkUBm3I",
+  "rootDir": "./dist"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/.clasp.json
-
 node_modules/
 .node_modules/
 built/*


### PR DESCRIPTION
clasp.jsonに記載のscriptIdが、オーナー以外でも普通に閲覧・確認できるものだと判明したため、clasp.jsonをリポジトリ追跡対象に追加。